### PR TITLE
Bump sqlx & expose sqlx feature rustls flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,8 @@ members = ["sqlxmq_macros", "sqlxmq_stress"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sqlx = { version = "0.5.1", features = [
+sqlx = { version = "0.5.2", features = [
     "postgres",
-    "runtime-tokio-native-tls",
     "chrono",
     "uuid",
 ] }
@@ -29,6 +28,11 @@ log = "0.4.14"
 serde_json = "1.0.64"
 serde = "1.0.124"
 sqlxmq_macros = { version = "0.1", path = "sqlxmq_macros" }
+
+[features]
+default = ["runtime-tokio-native-tls"]
+runtime-tokio-native-tls = ["sqlx/runtime-tokio-native-tls"]
+runtime-tokio-rustls = ["sqlx/runtime-tokio-rustls"]
 
 [dev-dependencies]
 dotenv = "0.15.0"


### PR DESCRIPTION
I'm looking to integrate this with the [actix-web-starter](https://github.com/secretkeysio/jelly-actix-web-starter) project I've been working on (needs a new job queue/engine due to a [licensing issue that I somehow missed](https://github.com/secretkeysio/jelly-actix-web-starter/issues/9)...), and so far it's pretty cool. Very nice project.

This PR should keep all the existing behavior but just exposes another sqlx runtime flag (and bumps sqlx to 0.5.2). If I've missed anything I'm all ears - hoping it's not too big a change.