### PR TITLE
Stress test cleanup

### DIFF
--- a/sqlxmq_stress/src/main.rs
+++ b/sqlxmq_stress/src/main.rs
@@ -77,6 +77,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let pool = Pool::connect(&env::var("DATABASE_URL")?).await?;
 
+    // Remove possible artifacts of previous canceled (ctrl+c) runs
+    sqlx::query!("delete from mq_payloads")
+        .execute(&pool)
+        .await?;
+    sqlx::query!("delete from mq_msgs").execute(&pool).await?;
+
     let registry = JobRegistry::new(&[example_job]);
 
     let _runner = registry

--- a/sqlxmq_stress/src/main.rs
+++ b/sqlxmq_stress/src/main.rs
@@ -59,7 +59,11 @@ async fn start_job(
             start_time: INSTANT_EPOCH.elapsed(),
         })?
         .spawn(&pool)
-        .await?;
+        .await
+        .map_err(|e| {
+            eprintln!("sqlxmq_stress::start_job {}", e);
+            e
+        })?;
     Ok(())
 }
 


### PR DESCRIPTION
After cancelling a stress test and running it again 
```rust
    CHANNEL.read().unwrap().unbounded_send(JobResult {
        duration: end_time - data.start_time,
    })?;
```
sometimes panics with `overflow when subtracting durations` (because of `static ref INSTANT_EPOCH` changing between the runs).