### PR TITLE
Move migration changes to separate files

### DIFF
--- a/migrations/20210316025847_setup.down.sql
+++ b/migrations/20210316025847_setup.down.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION mq_clear;
-DROP FUNCTION mq_clear_all;
 DROP FUNCTION mq_checkpoint;
 DROP FUNCTION mq_keep_alive;
 DROP FUNCTION mq_delete;

--- a/migrations/20210316025847_setup.up.sql
+++ b/migrations/20210316025847_setup.up.sql
@@ -287,24 +287,3 @@ RETURNS VOID AS $$
         id = msg_id;
 $$ LANGUAGE SQL;
 
--- Deletes all messages from a list of channel names.
-CREATE FUNCTION mq_clear(channel_names TEXT[])
-RETURNS VOID AS $$
-BEGIN
-    WITH deleted_ids AS (
-        DELETE FROM mq_msgs WHERE channel_name = ANY(channel_names) RETURNING id
-    )
-    DELETE FROM mq_payloads WHERE id IN (SELECT id FROM deleted_ids);
-END;
-$$ LANGUAGE plpgsql;
-
--- Deletes all messages.
-CREATE FUNCTION mq_clear_all()
-RETURNS VOID AS $$
-BEGIN
-    WITH deleted_ids AS (
-        DELETE FROM mq_msgs RETURNING id
-    )
-    DELETE FROM mq_payloads WHERE id IN (SELECT id FROM deleted_ids);
-END;
-$$ LANGUAGE plpgsql;

--- a/migrations/20210921115907_clear.down.sql
+++ b/migrations/20210921115907_clear.down.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION mq_clear;
+DROP FUNCTION mq_clear_all;

--- a/migrations/20210921115907_clear.up.sql
+++ b/migrations/20210921115907_clear.up.sql
@@ -1,0 +1,21 @@
+-- Deletes all messages from a list of channel names.
+CREATE FUNCTION mq_clear(channel_names TEXT[])
+RETURNS VOID AS $$
+BEGIN
+    WITH deleted_ids AS (
+        DELETE FROM mq_msgs WHERE channel_name = ANY(channel_names) RETURNING id
+    )
+    DELETE FROM mq_payloads WHERE id IN (SELECT id FROM deleted_ids);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Deletes all messages.
+CREATE FUNCTION mq_clear_all()
+RETURNS VOID AS $$
+BEGIN
+    WITH deleted_ids AS (
+        DELETE FROM mq_msgs RETURNING id
+    )
+    DELETE FROM mq_payloads WHERE id IN (SELECT id FROM deleted_ids);
+END;
+$$ LANGUAGE plpgsql;

--- a/sqlxmq_stress/migrations/20210316025847_setup.down.sql
+++ b/sqlxmq_stress/migrations/20210316025847_setup.down.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION mq_clear;
-DROP FUNCTION mq_clear_all;
 DROP FUNCTION mq_checkpoint;
 DROP FUNCTION mq_keep_alive;
 DROP FUNCTION mq_delete;

--- a/sqlxmq_stress/migrations/20210316025847_setup.up.sql
+++ b/sqlxmq_stress/migrations/20210316025847_setup.up.sql
@@ -287,24 +287,3 @@ RETURNS VOID AS $$
         id = msg_id;
 $$ LANGUAGE SQL;
 
--- Deletes all messages from a list of channel names.
-CREATE FUNCTION mq_clear(channel_names TEXT[])
-RETURNS VOID AS $$
-BEGIN
-    WITH deleted_ids AS (
-        DELETE FROM mq_msgs WHERE channel_name = ANY(channel_names) RETURNING id
-    )
-    DELETE FROM mq_payloads WHERE id IN (SELECT id FROM deleted_ids);
-END;
-$$ LANGUAGE plpgsql;
-
--- Deletes all messages.
-CREATE FUNCTION mq_clear_all()
-RETURNS VOID AS $$
-BEGIN
-    WITH deleted_ids AS (
-        DELETE FROM mq_msgs RETURNING id
-    )
-    DELETE FROM mq_payloads WHERE id IN (SELECT id FROM deleted_ids);
-END;
-$$ LANGUAGE plpgsql;

--- a/sqlxmq_stress/migrations/20210921115907_clear.down.sql
+++ b/sqlxmq_stress/migrations/20210921115907_clear.down.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION mq_clear;
+DROP FUNCTION mq_clear_all;

--- a/sqlxmq_stress/migrations/20210921115907_clear.up.sql
+++ b/sqlxmq_stress/migrations/20210921115907_clear.up.sql
@@ -1,0 +1,21 @@
+-- Deletes all messages from a list of channel names.
+CREATE FUNCTION mq_clear(channel_names TEXT[])
+RETURNS VOID AS $$
+BEGIN
+    WITH deleted_ids AS (
+        DELETE FROM mq_msgs WHERE channel_name = ANY(channel_names) RETURNING id
+    )
+    DELETE FROM mq_payloads WHERE id IN (SELECT id FROM deleted_ids);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Deletes all messages.
+CREATE FUNCTION mq_clear_all()
+RETURNS VOID AS $$
+BEGIN
+    WITH deleted_ids AS (
+        DELETE FROM mq_msgs RETURNING id
+    )
+    DELETE FROM mq_payloads WHERE id IN (SELECT id FROM deleted_ids);
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
Closes #11.

Moves the migration changes introduced in 5d287b7 to separate migration files, so existing requeuest deployments can migrate without issue.

I left the explicit naming of the `mq_msgs_channel_name_channel_args_after_message_id_idx` constraint in the original file, since that shouldn't cause any actual change of behavior, and just makes explicit what postgresql implicitly does anyway.