### PR TITLE
Document the macro-generated static

### DIFF
--- a/sqlxmq_macros/src/lib.rs
+++ b/sqlxmq_macros/src/lib.rs
@@ -231,6 +231,11 @@ pub fn job(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
+    let outer_docs = inner_fn
+        .attrs
+        .iter()
+        .filter(|attr| attr.path.is_ident("doc"));
+
     let vis = mem::replace(&mut inner_fn.vis, Visibility::Inherited);
     let name = mem::replace(&mut inner_fn.sig.ident, parse_quote! {inner});
     let fq_name = if let Some(name) = options.name {
@@ -281,6 +286,7 @@ pub fn job(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let expanded = quote! {
         #(#errors)*
+        #(#outer_docs)*
         #[allow(non_upper_case_globals)]
         #vis static #name: &'static sqlxmq::NamedJob = &{
             #inner_fn

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,7 @@ pub fn should_retry(error: &sqlx::Error) -> bool {
     if let Some(db_error) = error.as_database_error() {
         // It's more readable as a match
         #[allow(clippy::match_like_matches_macro)]
-        match (db_error.code().as_deref(), db_error.constraint().as_deref()) {
+        match (db_error.code().as_deref(), db_error.constraint()) {
             // Foreign key constraint violation on ordered channel
             (Some("23503"), Some("mq_msgs_after_message_id_fkey")) => true,
             // Unique constraint violation on ordered channel


### PR DESCRIPTION
`#[warn(missing_docs)]` complains about the generated static as it misses documentation. This should fix it.

Feel free the change the actual documentation.