### PR TITLE
becker/postgres-locking

### DIFF
--- a/migrations/20220204230312_locks.down.sql
+++ b/migrations/20220204230312_locks.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/migrations/20220204230312_locks.up.sql
+++ b/migrations/20220204230312_locks.up.sql
@@ -1,0 +1,126 @@
+-- Add up migration script here
+ALTER TABLE mq_msgs
+ADD COLUMN lock_number BIGINT;
+
+CREATE OR REPLACE FUNCTION mq_insert(new_messages mq_new_t[])
+RETURNS VOID AS $$
+BEGIN
+    PERFORM pg_notify(CONCAT('mq_', channel_name), '')
+    FROM unnest(new_messages) AS new_msgs
+    GROUP BY channel_name;
+
+    IF FOUND THEN
+        PERFORM pg_notify('mq', '');
+    END IF;
+
+    INSERT INTO mq_payloads (
+        id,
+        name,
+        payload_json,
+        payload_bytes
+    ) SELECT
+        id,
+        name,
+        payload_json::JSONB,
+        payload_bytes
+    FROM UNNEST(new_messages);
+
+    INSERT INTO mq_msgs (
+        id,
+        lock_number,
+        attempt_at,
+        attempts,
+        retry_backoff,
+        channel_name,
+        channel_args,
+        commit_interval,
+        after_message_id
+    )
+    SELECT
+        id,
+        ('x' || translate(id::text, '-', ''))::bit(64)::bigint,
+        NOW() + delay + COALESCE(commit_interval, INTERVAL '0'),
+        retries + 1,
+        retry_backoff,
+        channel_name,
+        channel_args,
+        commit_interval,
+        CASE WHEN ordered
+            THEN
+                LAG(id, 1, mq_latest_message(channel_name, channel_args))
+                OVER (PARTITION BY channel_name, channel_args, ordered ORDER BY id)
+            ELSE
+                NULL
+            END
+    FROM UNNEST(new_messages);
+END;
+$$ LANGUAGE plpgsql;
+
+UPDATE mq_msgs SET lock_number = ('x' || translate(id::text, '-', ''))::bit(64)::bigint WHERE lock_number IS NULL ;
+
+
+-- Main entry-point for job runner: pulls a batch of messages from the queue.
+CREATE FUNCTION mq_poll_locking(channel_names TEXT[], batch_size INT DEFAULT 1)
+RETURNS TABLE(
+    id UUID,
+    is_committed BOOLEAN,
+    name TEXT,
+    payload_json TEXT,
+    payload_bytes BYTEA,
+    retry_backoff INTERVAL,
+    wait_time INTERVAL
+) AS $$
+BEGIN
+    RETURN QUERY UPDATE mq_msgs
+    SET
+        attempt_at = CASE WHEN mq_msgs.attempts = 1 THEN NULL ELSE NOW() + mq_msgs.retry_backoff END,
+        attempts = mq_msgs.attempts - 1,
+        retry_backoff = mq_msgs.retry_backoff * 2
+    FROM (
+        SELECT
+            msgs.id,
+            msgs.lock_number
+        FROM mq_active_channels(channel_names, batch_size) AS active_channels
+        INNER JOIN LATERAL (
+            SELECT * FROM mq_msgs
+            WHERE mq_msgs.id != uuid_nil()
+            AND mq_msgs.attempt_at <= NOW()
+            AND mq_msgs.channel_name = active_channels.name
+            AND mq_msgs.channel_args = active_channels.args
+            AND NOT mq_uuid_exists(mq_msgs.after_message_id)
+            ORDER BY mq_msgs.attempt_at ASC
+            LIMIT batch_size
+        ) AS msgs ON TRUE
+        WHERE pg_try_advisory_xact_lock(lock_number)
+        LIMIT batch_size
+    ) AS messages_to_update
+    LEFT JOIN mq_payloads ON mq_payloads.id = messages_to_update.id
+    WHERE mq_msgs.id = messages_to_update.id 
+    RETURNING
+        mq_msgs.id,
+        mq_msgs.commit_interval IS NULL,
+        mq_payloads.name,
+        mq_payloads.payload_json::TEXT,
+        mq_payloads.payload_bytes,
+        mq_msgs.retry_backoff / 2,
+        interval '0' AS wait_time;
+
+    IF NOT FOUND THEN
+        RETURN QUERY SELECT
+            NULL::UUID,
+            NULL::BOOLEAN,
+            NULL::TEXT,
+            NULL::TEXT,
+            NULL::BYTEA,
+            NULL::INTERVAL,
+            MIN(mq_msgs.attempt_at) - NOW()
+        FROM mq_msgs
+        WHERE mq_msgs.id != uuid_nil()
+        AND NOT mq_uuid_exists(mq_msgs.after_message_id)
+        AND (channel_names IS NULL OR mq_msgs.channel_name = ANY(channel_names));
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+ALTER TABLE mq_msgs
+    ALTER COLUMN lock_number SET NOT NULL

--- a/sqlxmq_stress/.env
+++ b/sqlxmq_stress/.env
@@ -1,1 +1,3 @@
 DATABASE_URL=postgres://postgres:password@localhost/sqlxmq_stress
+MAX_JOBS=1000
+MIN_JOBS=50

--- a/sqlxmq_stress/README
+++ b/sqlxmq_stress/README
@@ -1,0 +1,8 @@
+# Create database
+database url is set in .env
+
+`pqsl -c 'create database sqlxmq_stress'`
+
+# run migrations
+
+`sqlx migrate run`

--- a/sqlxmq_stress/migrations/20220204230312_locks.down.sql
+++ b/sqlxmq_stress/migrations/20220204230312_locks.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/sqlxmq_stress/migrations/20220204230312_locks.up.sql
+++ b/sqlxmq_stress/migrations/20220204230312_locks.up.sql
@@ -1,0 +1,126 @@
+-- Add up migration script here
+ALTER TABLE mq_msgs
+ADD COLUMN lock_number BIGINT;
+
+CREATE OR REPLACE FUNCTION mq_insert(new_messages mq_new_t[])
+RETURNS VOID AS $$
+BEGIN
+    PERFORM pg_notify(CONCAT('mq_', channel_name), '')
+    FROM unnest(new_messages) AS new_msgs
+    GROUP BY channel_name;
+
+    IF FOUND THEN
+        PERFORM pg_notify('mq', '');
+    END IF;
+
+    INSERT INTO mq_payloads (
+        id,
+        name,
+        payload_json,
+        payload_bytes
+    ) SELECT
+        id,
+        name,
+        payload_json::JSONB,
+        payload_bytes
+    FROM UNNEST(new_messages);
+
+    INSERT INTO mq_msgs (
+        id,
+        lock_number,
+        attempt_at,
+        attempts,
+        retry_backoff,
+        channel_name,
+        channel_args,
+        commit_interval,
+        after_message_id
+    )
+    SELECT
+        id,
+        ('x' || translate(id::text, '-', ''))::bit(64)::bigint,
+        NOW() + delay + COALESCE(commit_interval, INTERVAL '0'),
+        retries + 1,
+        retry_backoff,
+        channel_name,
+        channel_args,
+        commit_interval,
+        CASE WHEN ordered
+            THEN
+                LAG(id, 1, mq_latest_message(channel_name, channel_args))
+                OVER (PARTITION BY channel_name, channel_args, ordered ORDER BY id)
+            ELSE
+                NULL
+            END
+    FROM UNNEST(new_messages);
+END;
+$$ LANGUAGE plpgsql;
+
+UPDATE mq_msgs SET lock_number = ('x' || translate(id::text, '-', ''))::bit(64)::bigint WHERE lock_number IS NULL ;
+
+
+-- Main entry-point for job runner: pulls a batch of messages from the queue.
+CREATE FUNCTION mq_poll_locking(channel_names TEXT[], batch_size INT DEFAULT 1)
+RETURNS TABLE(
+    id UUID,
+    is_committed BOOLEAN,
+    name TEXT,
+    payload_json TEXT,
+    payload_bytes BYTEA,
+    retry_backoff INTERVAL,
+    wait_time INTERVAL
+) AS $$
+BEGIN
+    RETURN QUERY UPDATE mq_msgs
+    SET
+        attempt_at = CASE WHEN mq_msgs.attempts = 1 THEN NULL ELSE NOW() + mq_msgs.retry_backoff END,
+        attempts = mq_msgs.attempts - 1,
+        retry_backoff = mq_msgs.retry_backoff * 2
+    FROM (
+        SELECT
+            msgs.id,
+            msgs.lock_number
+        FROM mq_active_channels(channel_names, batch_size) AS active_channels
+        INNER JOIN LATERAL (
+            SELECT * FROM mq_msgs
+            WHERE mq_msgs.id != uuid_nil()
+            AND mq_msgs.attempt_at <= NOW()
+            AND mq_msgs.channel_name = active_channels.name
+            AND mq_msgs.channel_args = active_channels.args
+            AND NOT mq_uuid_exists(mq_msgs.after_message_id)
+            ORDER BY mq_msgs.attempt_at ASC
+            LIMIT batch_size
+        ) AS msgs ON TRUE
+        WHERE pg_try_advisory_xact_lock(lock_number)
+        LIMIT batch_size
+    ) AS messages_to_update
+    LEFT JOIN mq_payloads ON mq_payloads.id = messages_to_update.id
+    WHERE mq_msgs.id = messages_to_update.id 
+    RETURNING
+        mq_msgs.id,
+        mq_msgs.commit_interval IS NULL,
+        mq_payloads.name,
+        mq_payloads.payload_json::TEXT,
+        mq_payloads.payload_bytes,
+        mq_msgs.retry_backoff / 2,
+        interval '0' AS wait_time;
+
+    IF NOT FOUND THEN
+        RETURN QUERY SELECT
+            NULL::UUID,
+            NULL::BOOLEAN,
+            NULL::TEXT,
+            NULL::TEXT,
+            NULL::BYTEA,
+            NULL::INTERVAL,
+            MIN(mq_msgs.attempt_at) - NOW()
+        FROM mq_msgs
+        WHERE mq_msgs.id != uuid_nil()
+        AND NOT mq_uuid_exists(mq_msgs.after_message_id)
+        AND (channel_names IS NULL OR mq_msgs.channel_name = ANY(channel_names));
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+ALTER TABLE mq_msgs
+    ALTER COLUMN lock_number SET NOT NULL


### PR DESCRIPTION
Dearest Reviewer,

In an attempt to allow more then one runner to run at a time I have
added in postgres advisory locks to the polling call. This requires a
pre calculated number which is done on insert.

I have updated the stress test and added some ENV values and a README.
The stress test results are inline with what I get on the main branch.

```
Standard:
min: 0.038561309s
max: 37.321387572s
median: 29.594086093s
95th percentile: 34.564979967s
throughput: 263.7400277852498/s
Locking:
min: 0.979646111s
max: 37.211344452s
median: 29.578954612s
95th percentile: 34.722588948s
throughput: 266.5816441194382/s
```

I used pg_try_advisory_xact_lock because it is transaction based not
session based.

Becker