### PR TITLE
refactor: Replace dotenv with dotenvy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = ["sqlxmq_macros", "sqlxmq_stress"]
 [dependencies]
 sqlx = { version = "0.6.0", features = ["postgres", "chrono", "uuid"] }
 tokio = { version = "1.8.3", features = ["full"] }
-dotenv = "0.15.0"
+dotenvy = "0.15.3"
 chrono = "0.4.19"
 uuid = { version = "1.1.2", features = ["v4"] }
 log = "0.4.14"
@@ -32,7 +32,7 @@ runtime-tokio-native-tls = ["sqlx/runtime-tokio-native-tls"]
 runtime-tokio-rustls = ["sqlx/runtime-tokio-rustls"]
 
 [dev-dependencies]
-dotenv = "0.15.0"
+dotenvy = "0.15.3"
 pretty_env_logger = "0.4.0"
 futures = "0.3.13"
 tokio = { version = "1", features = ["full"] }

--- a/examples/graceful-shutdown.rs
+++ b/examples/graceful-shutdown.rs
@@ -4,7 +4,7 @@ use tokio::time;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
     let db = sqlx::PgPool::connect(&std::env::var("DATABASE_URL").unwrap()).await?;
 
     sleep.builder().set_json(&5u64)?.spawn(&db).await?;

--- a/sqlxmq_stress/Cargo.toml
+++ b/sqlxmq_stress/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 sqlxmq = { path = ".." }
 tokio = { version = "1.4.0", features = ["full"] }
-dotenv = "0.15.0"
+dotenvy = "0.15.3"
 sqlx = "0.6.0"
 serde = "1.0.125"
 lazy_static = "1.4.0"

--- a/sqlxmq_stress/src/main.rs
+++ b/sqlxmq_stress/src/main.rs
@@ -80,7 +80,7 @@ async fn schedule_tasks(num_jobs: usize, interval: Duration, pool: Pool<Postgres
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
 
     let pool = Pool::connect(&env::var("DATABASE_URL")?).await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,7 +294,7 @@ mod tests {
 
         let guard = TEST_MUTEX.lock().await;
 
-        let _ = dotenv::dotenv();
+        let _ = dotenvy::dotenv();
 
         INIT_LOGGER.call_once(pretty_env_logger::init);
 


### PR DESCRIPTION
`dotenv`, one of the `sqlxmq`'s dependencies, is [unmaintained](https://github.com/dotenv-rs/dotenv/issues/74). The project has been [forked](https://github.com/dotenv-rs/dotenv/issues/74), and the fork has been actively maintained since. The public API remains unchanged, so it should work as a drop-in replacement.